### PR TITLE
add php7 target

### DIFF
--- a/src/travix/Travix.hx
+++ b/src/travix/Travix.hx
@@ -98,6 +98,7 @@ class Travix {
       case 'flash': new FlashCommand(cmd, args);
       case 'cpp': new CppCommand(cmd, args);
       case 'php': new PhpCommand(cmd, args);
+      case 'php7': new Php7Command(cmd, args);
       case 'python': new PythonCommand(cmd, args);
       case 'cs': new CsCommand(cmd, args);
       case 'lua': new LuaCommand(cmd, args);

--- a/src/travix/commands/HelpCommand.hx
+++ b/src/travix/commands/HelpCommand.hx
@@ -13,7 +13,8 @@ class HelpCommand extends Command {
     println('  neko - run tests on neko');
     println('  node - run tests on nodejs (with hxnodejs)');
     println('  js - run tests on js (with phantomjs)');
-    println('  php - run tests on php');
+    println('  php - run tests on php 5.x');
+    println('  php7 - run tests on php 7.x');
     println('  java - run tests on java');
     println('  flash - run tests on flash');
     println('  python - run tests on python');

--- a/src/travix/commands/InitCommand.hx
+++ b/src/travix/commands/InitCommand.hx
@@ -14,7 +14,7 @@ using sys.io.File;
 class InitCommand extends Command {
 	static inline var PROFILE = 'https://travis-ci.org/profile/';
   static inline var DEFAULT_PLATFORMS = 'interp, neko, node, python, java';
-  static inline var ALL = 'interp,neko,python,node,js,flash,java,cpp,cs,php,lua';
+  static inline var ALL = 'interp,neko,python,node,js,flash,java,cpp,cs,php,php7,lua';
   
   static inline var TRAVIS_CONFIG = '.travis.yml';
 	static inline var TESTS = @:privateAccess Travix.TESTS;

--- a/src/travix/commands/Php7Command.hx
+++ b/src/travix/commands/Php7Command.hx
@@ -2,9 +2,9 @@ package travix.commands;
 
 import Sys.*;
 
-class PhpCommand extends Command {
+class Php7Command extends Command {
 
-  var phpVersionPattern:EReg = new EReg("PHP 5\\.*","");
+  var phpVersionPattern:EReg = new EReg("PHP 7\\.*","");
 
   override function execute() {
 
@@ -15,8 +15,8 @@ class PhpCommand extends Command {
     foldOutput('php-install', function() {
       switch Sys.systemName() {
         case 'Linux':
-          phpCmd = 'php5.6';
-          phpPackage = 'php5.6';
+          phpCmd = 'php7.1';
+          phpPackage = 'php7.1';
           switch(tryToRun(phpCmd, ['--version'])) {
             case Success(out): phpInstallationRequired = !phpVersionPattern.match(out);
             case Failure(_):   phpInstallationRequired = true;
@@ -28,7 +28,7 @@ class PhpCommand extends Command {
           }
         case 'Mac':
           phpCmd = 'php';
-          phpPackage = 'php56';
+          phpPackage = 'php71';
           switch(tryToRun(phpCmd, ['--version'])) {
             case Success(out): phpInstallationRequired = !phpVersionPattern.match(out);
             case Failure(_):   phpInstallationRequired = true;
@@ -49,7 +49,7 @@ class PhpCommand extends Command {
       exec(phpCmd, ['--version']);
     });
 
-    build(['-php', 'bin/php'], function () {
+    build(['-php', 'bin/php', '-D', 'php7'], function () {
       exec(phpCmd, ['-d', 'xdebug.max_nesting_level=9999', 'bin/php/index.php']);
     });
 


### PR DESCRIPTION
Adds PHP7 support and updates PHP target to explicitly use PHP v5.6 instead of currently v5.5

Solves https://github.com/back2dos/travix/issues/55