### PR TITLE
Install newer mono version on Linux.

### DIFF
--- a/src/travix/commands/CsCommand.hx
+++ b/src/travix/commands/CsCommand.hx
@@ -14,7 +14,7 @@ class CsCommand extends Command {
       exec('eval', ['sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF']);
       switch tryToRun('lsb_release', ['-cs']) {
         case Success('precise\n'):
-          exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
+          exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu precise main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
         case Success('trusty\n'):
           exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
         case Success('xenial\n'):

--- a/src/travix/commands/CsCommand.hx
+++ b/src/travix/commands/CsCommand.hx
@@ -1,27 +1,40 @@
 package travix.commands;
 
-using StringTools;
-
 class CsCommand extends Command {
-  
+
   override function execute() {
-    
-    if (!Travix.isWindows)
-      if (tryToRun('mono', ['--version']).match(Failure(_, _))) {
-        if(Travix.isLinux) {
-          aptGet('mono-devel');
-          aptGet('mono-mcs');
-        } else {
-          aptGet('mono');
-        }
+
+    if (Travix.isMac) {
+
+      aptGet('mono');
+
+    } else if (Travix.isLinux) {
+
+      // http://www.mono-project.com/download/#download-lin
+      exec('eval', ['sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF']);
+      switch tryToRun('lsb_release', ['-cs']) {
+        case Success('precise\n'):
+          exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
+        case Success('trusty\n'):
+          exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
+        case Success('xenial\n'):
+          exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
+        default:
       }
-      
+      exec('eval', ['sudo apt-get update']);
+
+      aptGet('mono-devel');
+      aptGet('mono-mcs');
+
+      // print the effective mono version
+      exec('mono', ['-V']);
+    }
+
     var main = Travix.getMainClassLocalName();
-    
+
     installLib('hxcs');
-    
+
     build(['-cs', 'bin/cs/'], function () {
-    
       if (Travix.isWindows)
         exec('bin\\cs\\bin\\$main.exe');
       else


### PR DESCRIPTION
This solves compile-time error "error CS1061: Type `System.Text.StringBuilder' does not contain a definition for `Clear' and no extension method `Clear' of type `System.Text.StringBuilder' could be found. Are you missing an assembly reference?"