### PR TITLE
Use new Linux FlashPlayer Debugger 26 x64

### DIFF
--- a/src/travix/commands/FlashCommand.hx
+++ b/src/travix/commands/FlashCommand.hx
@@ -35,13 +35,13 @@ class FlashCommand extends Command {
         exec('eval', ['wget -nv -O flash_player_sa_linux.tar.gz https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux_debug.x86_64.tar.gz']);
         exec('eval', ['tar -C "$flashPath" -xf flash_player_sa_linux.tar.gz --wildcards "flashplayerdebugger"']);
         exec('eval', ['rm -f flash_player_sa_linux.tar.gz']);
-      }
-      
-      // Required flash libs
-      var packages = ["libcurl3","libglib2.0-0","libx11-6", "libxext6","libxt6",
-          "libxcursor1","libnss3", "libgtk2.0-0"];
+        
+        // Required flash libs
+        var packages = ["libcurl3","libglib2.0-0","libx11-6", "libxext6","libxt6",
+            "libxcursor1","libnss3", "libgtk2.0-0"];
 
-      for (pack in packages) aptGet(pack);
+        for (pack in packages) aptGet(pack);
+      }
       
       // Tail the logfile. Must use eval to start tail in background, to see the output.
       exec('eval', ['tail -f --follow=name --retry "$flashPath/Logs/flashlog.txt" &']);

--- a/src/travix/commands/FlashCommand.hx
+++ b/src/travix/commands/FlashCommand.hx
@@ -37,6 +37,12 @@ class FlashCommand extends Command {
         exec('eval', ['rm -f flash_player_sa_linux.tar.gz']);
       }
       
+      // Required flash libs
+      var packages = ["libcurl3","libglib2.0-0","libx11-6", "libxext6","libxt6",
+          "libxcursor1","libnss3", "libgtk2.0-0"];
+
+      for (pack in packages) aptGet(pack);
+      
       // Tail the logfile. Must use eval to start tail in background, to see the output.
       exec('eval', ['tail -f --follow=name --retry "$flashPath/Logs/flashlog.txt" &']);
     });


### PR DESCRIPTION
The until now installed FlashPlayer 11 Debug Player does not support the concurrency API introduced with Flash 11.5 http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/concurrent/Condition.html

The newer version also is 64bit which simplifies the installation since no messing around with 32bit libraries is required. It may also solve the "unexplained crashes" documented in the source code.