### PR TITLE
Workaround for "Homebrew must be run under Ruby 2.3!" error on MacOSX for Js, PHP and Python target.

### DIFF
--- a/src/travix/commands/JsCommand.hx
+++ b/src/travix/commands/JsCommand.hx
@@ -4,32 +4,32 @@ using sys.io.File;
 using sys.FileSystem;
 
 class JsCommand extends Command {
-  
-  
+
+
   override function execute() {
-    
+
     var phantomjs = 'phantomjs';
-    
+
     if(Travix.isTravis) {
       if(Travix.isMac) {
+        exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
         aptGet('phantomjs');
       } else if(Travix.isLinux) {
         var PHANTOM_JS = "phantomjs-2.1.1-linux-x86_64";
-        
+
         foldOutput('phantomjs-update', function() {
           exec('sudo', ['apt-get', 'update']);
-          
-          for(dep in ['build-essential', 'chrpath', 'libssl-dev', 'libxft-dev', 'libfreetype6', 'libfreetype6-dev', 'libfontconfig1', 'libfontconfig1-dev'])
+                    for(dep in ['build-essential', 'chrpath', 'libssl-dev', 'libxft-dev', 'libfreetype6', 'libfreetype6-dev', 'libfontconfig1', 'libfontconfig1-dev'])
             aptGet(dep);
 
           exec('wget', ['https://github.com/Medium/phantomjs/releases/download/v2.1.1/$PHANTOM_JS.tar.bz2']);
           exec('tar', ['xvjf', '$PHANTOM_JS.tar.bz2']);
-          
+
           phantomjs = '$PHANTOM_JS/bin/phantomjs';
         });
       }
     }
-    
+
     build(['-js', 'bin/js/tests.js'], function () {
       var index = 'bin/js/index.html';
       if(!index.exists()) index.saveContent(defaultIndexHtml());
@@ -39,7 +39,7 @@ class JsCommand extends Command {
       exec(phantomjs, ['--web-security=no', runPhantom]);
     });
   }
-  
+
   macro static function defaultIndexHtml() {
     return Macro.loadFile('js/index.html');
   }

--- a/src/travix/commands/Php7Command.hx
+++ b/src/travix/commands/Php7Command.hx
@@ -36,6 +36,7 @@ class Php7Command extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
+            exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
             exec('brew', ['tap', 'homebrew/homebrew-php']);
             exec('brew', ['install', '--without-apache', '--without-snmp', phpPackage]);
           }

--- a/src/travix/commands/PhpCommand.hx
+++ b/src/travix/commands/PhpCommand.hx
@@ -36,6 +36,7 @@ class PhpCommand extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
+            exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
             exec('brew', ['tap', 'homebrew/homebrew-php']);
             exec('brew', ['install', '--without-apache', '--without-snmp', phpPackage]);
           }

--- a/src/travix/commands/PythonCommand.hx
+++ b/src/travix/commands/PythonCommand.hx
@@ -1,11 +1,14 @@
 package travix.commands;
 
 class PythonCommand extends Command {
-  
+
   override function execute() {
     build(['-python', 'bin/python/tests.py'], function () {
-      if (tryToRun('python3', ['--version']).match(Failure(_, _)))
+      if (tryToRun('python3', ['--version']).match(Failure(_, _))) {
+        if (Travix.isMac)
+          exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
         aptGet('python3');
+      }
       exec('python3', ['bin/python/tests.py']);
     });
   }


### PR DESCRIPTION
Suddenly travis jobs targeting PHP, JS and Python fail with

```bash
/usr/local/Homebrew/Library/Homebrew/brew.rb:12:in `<main>': Homebrew must be run under Ruby 2.3! You're running 2.0.0. (RuntimeError)
The command "haxelib run travix $HAXE_TARGET" exited with 1
Done. Your build exited with 1.
```

Executing `brew update` before `brew install` solves this. See https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197