### PR TITLE
Fix "Homebrew must be run under Ruby 2.3!" for all Mac OS targets.

### DIFF
--- a/src/travix/Command.hx
+++ b/src/travix/Command.hx
@@ -1,7 +1,5 @@
 package travix;
 
-import haxe.*;
-import haxe.ds.Option;
 import Sys.*;
 import sys.io.Process;
 
@@ -14,7 +12,7 @@ class Command {
 
   var cmd:String;
   var args:Array<String>;
-  var isFirstPackageInstallation:Bool = true;
+  var isFirstPackageInstallation = true;
 
   public function new(cmd, args) {
     this.cmd = cmd;
@@ -224,19 +222,19 @@ class Command {
       switch Sys.systemName() {
         case 'Linux':
           if (isFirstPackageInstallation) {
-            exec('apt-get', 'update');
+            exec('apt-get', ['update']);
             isFirstPackageInstallation = false;
           }
           exec('sudo', ['apt-get', 'install', '-qq', packageName].concat(if (additionalArgs == null) [] else additionalArgs));
         case 'Mac':
           if (isFirstPackageInstallation) {
-            exec('brew', 'update'); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
+            exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
             isFirstPackageInstallation = false;
           }
           exec('brew', ['install', packageName].concat(if (additionalArgs == null) [] else additionalArgs));
         case v:
           println('WARN: Don\'t know how to install packages on $v');
-        }
+      }
     });
   }
 }

--- a/src/travix/commands/CppCommand.hx
+++ b/src/travix/commands/CppCommand.hx
@@ -3,32 +3,32 @@ package travix.commands;
 import Sys.*;
 
 class CppCommand extends Command {
-  
+
   override function execute() {
     var main = Travix.getMainClassLocalName();
-    
+
     if (getEnv('TRAVIS_HAXE_VERSION') == 'development') {
-      
-      if(systemName() == 'Linux') {
-          aptGet('gcc-multilib');
-          aptGet('g++-multilib'); 
+
+      if(Travix.isLinux) {
+          installPackage('gcc-multilib');
+          installPackage('g++-multilib');
       }
-      
+
       if (!libInstalled('hxcpp')) {
         foldOutput('git-hxcpp', function() {
           exec('haxelib', ['git', 'hxcpp', 'https://github.com/HaxeFoundation/hxcpp.git']);
           withCwd(run('haxelib', ['path', 'hxcpp']).split('\n')[0], buildHxcpp);
         });
-      }      
+      }
     }
     else installLib('hxcpp');
-    
+
     build(['-cpp', 'bin/cpp'], function () {
       var outputFile = main + (isDebugBuild() ? '-debug' : '');
       exec('./bin/cpp/$outputFile');
     });
   }
-  
+
   function buildHxcpp() {
     withCwd('tools/hxcpp', exec.bind('haxe', ['compile.hxml']));
     withCwd('project', exec.bind('neko', ['build.n']));

--- a/src/travix/commands/CsCommand.hx
+++ b/src/travix/commands/CsCommand.hx
@@ -6,7 +6,7 @@ class CsCommand extends Command {
 
     if (Travix.isMac) {
 
-      aptGet('mono');
+      installPackage('mono');
 
     } else if (Travix.isLinux) {
 
@@ -21,10 +21,9 @@ class CsCommand extends Command {
           exec('eval', ['echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-official.list']);
         default:
       }
-      exec('eval', ['sudo apt-get update']);
 
-      aptGet('mono-devel');
-      aptGet('mono-mcs');
+      installPackage('mono-devel');
+      installPackage('mono-mcs');
 
       // print the effective mono version
       exec('mono', ['-V']);

--- a/src/travix/commands/FlashCommand.hx
+++ b/src/travix/commands/FlashCommand.hx
@@ -3,7 +3,7 @@ package travix.commands;
 import Sys.*;
 
 class FlashCommand extends Command {
-  
+
   override function execute() {
 
     // if we are not on Linux we only compile but do not run the tests
@@ -35,14 +35,20 @@ class FlashCommand extends Command {
         exec('eval', ['wget -nv -O flash_player_sa_linux.tar.gz https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flash_player_sa_linux_debug.x86_64.tar.gz']);
         exec('eval', ['tar -C "$flashPath" -xf flash_player_sa_linux.tar.gz --wildcards "flashplayerdebugger"']);
         exec('eval', ['rm -f flash_player_sa_linux.tar.gz']);
-        
-        // Required flash libs
-        var packages = ["libcurl3","libglib2.0-0","libx11-6", "libxext6","libxt6",
-            "libxcursor1","libnss3", "libgtk2.0-0"];
 
-        for (pack in packages) aptGet(pack);
+        // Required flash libs
+        installPackages([
+          "libcurl3",
+          "libglib2.0-0",
+          "libgtk2.0-0",
+          "libnss3",
+          "libx11-6",
+          "libxcursor1",
+          "libxext6",
+          "libxt6"
+        ]);
       }
-      
+
       // Tail the logfile. Must use eval to start tail in background, to see the output.
       exec('eval', ['tail -f --follow=name --retry "$flashPath/Logs/flashlog.txt" &']);
     });

--- a/src/travix/commands/JsCommand.hx
+++ b/src/travix/commands/JsCommand.hx
@@ -26,7 +26,7 @@ class JsCommand extends Command {
             'libfreetype6-dev',
             'libssl-dev',
             'libxft-dev'
-          ])
+          ]);
 
           exec('wget', ['https://github.com/Medium/phantomjs/releases/download/v2.1.1/$PHANTOM_JS.tar.bz2']);
           exec('tar', ['xvjf', '$PHANTOM_JS.tar.bz2']);

--- a/src/travix/commands/JsCommand.hx
+++ b/src/travix/commands/JsCommand.hx
@@ -12,15 +12,21 @@ class JsCommand extends Command {
 
     if(Travix.isTravis) {
       if(Travix.isMac) {
-        exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
-        aptGet('phantomjs');
+        installPackage('phantomjs');
       } else if(Travix.isLinux) {
         var PHANTOM_JS = "phantomjs-2.1.1-linux-x86_64";
 
         foldOutput('phantomjs-update', function() {
-          exec('sudo', ['apt-get', 'update']);
-                    for(dep in ['build-essential', 'chrpath', 'libssl-dev', 'libxft-dev', 'libfreetype6', 'libfreetype6-dev', 'libfontconfig1', 'libfontconfig1-dev'])
-            aptGet(dep);
+          installPackages([
+            'build-essential',
+            'chrpath',
+            'libfontconfig1',
+            'libfontconfig1-dev',
+            'libfreetype6',
+            'libfreetype6-dev',
+            'libssl-dev',
+            'libxft-dev'
+          ])
 
           exec('wget', ['https://github.com/Medium/phantomjs/releases/download/v2.1.1/$PHANTOM_JS.tar.bz2']);
           exec('tar', ['xvjf', '$PHANTOM_JS.tar.bz2']);

--- a/src/travix/commands/LuaCommand.hx
+++ b/src/travix/commands/LuaCommand.hx
@@ -10,11 +10,16 @@ class LuaCommand extends Command {
           if(command('eval', ['bash -c "[ \\"`lsb_release -s -c`\\" == \\"precise\\" ]"']) == 0) {
             // Required repo for precise to build cmake
             exec('eval', ['sudo add-apt-repository -y ppa:george-edison55/precise-backports']);
-            exec('eval', ['sudo apt-get update']);
           }
 
-          for(pack in ["lua5.2","make","cmake","unzip","libpcre3","libpcre3-dev"])
-            aptGet(pack);
+          installPackages([
+            "cmake",
+            "libpcre3",
+            "libpcre3-dev",
+            "lua5.2",
+            "make",
+            "unzip"
+          ]);
 
           var luaRocksVersion = '2.4.2';
 
@@ -39,7 +44,7 @@ class LuaCommand extends Command {
           exec('rm', ['-f', 'luarocks-$luaRocksVersion.tar.gz']);
           exec('rm', ['-rf', 'luarocks-$luaRocksVersion']);
         } else if(Travix.isMac) {
-          aptGet('lua');
+          installPackage('lua');
         }
 
         // Install lua libraries

--- a/src/travix/commands/Php7Command.hx
+++ b/src/travix/commands/Php7Command.hx
@@ -22,11 +22,14 @@ class Php7Command extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
-            exec('sudo', ['apt-get', '-qy', 'install', 'software-properties-common']);  // ensure add-apt-repository command is present
-            exec('sudo', ['add-apt-repository', '-y', 'ppa:ondrej/php']);
-            exec('sudo', ['apt-get', 'update']);
-            for (pgk in ['cli', 'mbstring', 'mcrypt', 'xml'])
-                exec('sudo', ['apt-get', '-q', '-y', '--allow-unauthenticated', 'install', phpPackage + '-' + pgk]);
+            installPackage('software-properties-common');  // ensure 'add-apt-repository' command is present
+            exec('sudo', ['add-apt-repository', '-u', '-y', 'ppa:ondrej/php']);
+            installPackages([
+              phpPackage + "-cli",
+              phpPackage + "-mbstring",
+              phpPackage + "-mcrypt",
+              phpPackage + "-xml"
+            ], [ "--allow-unauthenticated" ]);
           }
         case 'Mac':
           phpCmd = 'php';
@@ -36,9 +39,8 @@ class Php7Command extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
-            exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
             exec('brew', ['tap', 'homebrew/homebrew-php']);
-            exec('brew', ['install', '--without-apache', '--without-snmp', phpPackage]);
+            installPackage(phpPackage, ['--without-apache', '--without-snmp']);
           }
         case v:
           phpCmd = 'php';

--- a/src/travix/commands/PhpCommand.hx
+++ b/src/travix/commands/PhpCommand.hx
@@ -22,11 +22,14 @@ class PhpCommand extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
-            exec('sudo', ['apt-get', '-qy', 'install', 'software-properties-common']);  // ensure add-apt-repository command is present
-            exec('sudo', ['add-apt-repository', '-y', 'ppa:ondrej/php']);
-            exec('sudo', ['apt-get', 'update']);
-            for (pgk in ['cli', 'mbstring', 'mcrypt', 'xml'])
-                exec('sudo', ['apt-get', '-q', '-y', '--allow-unauthenticated', 'install', phpPackage + '-' + pgk]);
+            installPackage('software-properties-common');  // ensure 'add-apt-repository' command is present
+            exec('sudo', ['add-apt-repository', '-u', '-y', 'ppa:ondrej/php']);
+            installPackages([
+              phpPackage + "-cli",
+              phpPackage + "-mbstring",
+              phpPackage + "-mcrypt",
+              phpPackage + "-xml"
+            ], [ "--allow-unauthenticated" ]);
           }
         case 'Mac':
           phpCmd = 'php';
@@ -36,9 +39,8 @@ class PhpCommand extends Command {
             case Failure(_):   phpInstallationRequired = true;
           }
           if (phpInstallationRequired) {
-            exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
             exec('brew', ['tap', 'homebrew/homebrew-php']);
-            exec('brew', ['install', '--without-apache', '--without-snmp', phpPackage]);
+            installPackage(phpPackage, ['--without-apache', '--without-snmp']);
           }
         case v:
           phpCmd = 'php';

--- a/src/travix/commands/PythonCommand.hx
+++ b/src/travix/commands/PythonCommand.hx
@@ -5,9 +5,7 @@ class PythonCommand extends Command {
   override function execute() {
     build(['-python', 'bin/python/tests.py'], function () {
       if (tryToRun('python3', ['--version']).match(Failure(_, _))) {
-        if (Travix.isMac)
-          exec('brew', ['update']); // to prevent "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197
-        aptGet('python3');
+        installPackage('python3');
       }
       exec('python3', ['bin/python/tests.py']);
     });


### PR DESCRIPTION
* Renamed Command#aptGet to Command#installPackage for clarity. 
* Added Command#installPackages()
* Command#installPackage now automatically executes "apt-get update"/"brew update" on it's first invocation before any packages are installed. This is mainly to fix "Homebrew must be run under Ruby 2.3!" https://github.com/travis-ci/travis-ci/issues/8552#issuecomment-335321197 for all targets on Mac OS.