### PR TITLE
Passes all arguments along as rest arguments to the command.

### DIFF
--- a/src/travix/Travix.hx
+++ b/src/travix/Travix.hx
@@ -96,6 +96,12 @@ class Travix {
     
     if(Sys.getEnv('HAXELIB_RUN') == '1')
       Sys.setCwd(args.pop());
+
+    // Remove the first argument (target), add "--" to get the others
+    // into rest arguments.
+    var first = args.shift();
+    args.unshift("--");
+    args.unshift(first);
       
     tink.Cli.process(args, new Travix()).handle(tink.Cli.exit);
   }


### PR DESCRIPTION
When the commit that closed haxetink/tink_cli#7 is released on haxelib, this can be used to pass all arguments along to the command as rest arguments.