### PR TITLE
Fix "Uncaught exception - [file_contents,extraParams.hxml]" on Java builds

### DIFF
--- a/src/travix/commands/JavaCommand.hx
+++ b/src/travix/commands/JavaCommand.hx
@@ -16,12 +16,15 @@ class JavaCommand extends Command {
     installLib('hxjava');
     
     build('java', ['-java', 'bin/java'].concat(rest), function () {
+      // must be executed while in project root, i.e. outside withCwd('bin/java')
+      var isDebugBuild = isDebugBuild(rest);
+
       withCwd('bin/java', function() {
         if('.buckconfig'.exists()) {
           exec('buck', ['build', ':run']);
           exec('buck', ['run', ':run']);
         } else {
-          var outputFile = main + (isDebugBuild(rest) ? '-Debug' : '');
+          var outputFile = main + (isDebugBuild ? '-Debug' : '');
           exec('java', ['-jar', '$outputFile.jar']);
         }
       });


### PR DESCRIPTION
When running `haxelib run travix java` the following exception may be thrown:

```
haxelib run hxjava hxjava_build.txt --haxe-version 4105 --feature-level 1
javac.exe "-sourcepath" "src" "-d" "obj" "-g" "@cmd"
Called from ? line 1
Called from tink/Cli.hx line 19
Called from tink/core/Future.hx line 488
Called from tink/core/Future.hx line 466
Called from tink/core/Future.hx line 492
Called from tink/core/Future.hx line 106
Called from tink/cli/Macro.hx line 392
Called from tink/cli/Macro.hx line 493
Called from travix/Travix.hx line 231
Called from travix/commands/JavaCommand.hx line 18
Called from travix/Command.hx line 171
Called from travix/commands/JavaCommand.hx line 19
Called from travix/Command.hx line 230
Called from travix/commands/JavaCommand.hx line 24
Called from travix/Command.hx line 193
Called from travix/Command.hx line 180
Called from travix/Command.hx line 177
Called from haxe-4.1.5/std/neko/_std/sys/io/File.hx line 29
Uncaught exception - [file_contents,extraParams.hxml]
```

This occurs when `test.hxml` relatively references `extraParams.hxml` and `isDebugBuild()` is executed after `JavaCommand` changed the working directory into a sub directory of the project root.