### PR TITLE
Don't change working directory to "bin/java" when running java builds.

### DIFF
--- a/src/travix/commands/JavaCommand.hx
+++ b/src/travix/commands/JavaCommand.hx
@@ -16,18 +16,15 @@ class JavaCommand extends Command {
     installLib('hxjava');
     
     build('java', ['-java', 'bin/java'].concat(rest), function () {
-      // must be executed while in project root, i.e. outside withCwd('bin/java')
-      var isDebugBuild = isDebugBuild(rest);
-
-      withCwd('bin/java', function() {
-        if('.buckconfig'.exists()) {
+      if('.buckconfig'.exists()) {
+        withCwd('bin/java', function() {
           exec('buck', ['build', ':run']);
           exec('buck', ['run', ':run']);
-        } else {
-          var outputFile = main + (isDebugBuild ? '-Debug' : '');
-          exec('java', ['-jar', '$outputFile.jar']);
-        }
-      });
+        });
+      } else {
+        var outputFile = main + (isDebugBuild(rest) ? '-Debug' : '');
+        exec('java', ['-jar', 'bin/java/$outputFile.jar']);
+      }
     });
   }
 }


### PR DESCRIPTION
This was introduced for an unknown reason with https://github.com/back2dos/travix/commit/69c2b8ffe9cef9282d4cca671e14c1331140d474 and results in different build behavior on Java compared to all other
platforms.

I moved the changing of the CWD inside the "buck" related `if` branch, however I would prefer to have the buck config stuff removed again completely since it is not documented and only implemented for the java platform - thus worshiping the maximum surprise principal.

By undoing the CWD change I could also revert my changes from https://github.com/back2dos/travix/commit/9ebeb8ec81798d5e9346826c0a10217ddf5164cf.