### PR TITLE
Fix CORS (and cookies) with localhost with travix js

### DIFF
--- a/src/travix/js/run.js
+++ b/src/travix/js/run.js
@@ -5,7 +5,7 @@ var url = 'http://localhost:8912/run.html';
 (async () => {
   server.listen(8912);
   const browser = await puppeteer.launch({
-	headless: true,
+    headless: true,
     devtools: true,
     args: [
         '--disable-web-security',

--- a/src/travix/js/run.js
+++ b/src/travix/js/run.js
@@ -4,7 +4,15 @@ var url = 'http://localhost:8912/run.html';
 
 (async () => {
   server.listen(8912);
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+	headless: true,
+    devtools: true,
+    args: [
+        '--disable-web-security',
+        '--disable-features=IsolateOrigins',
+        '--disable-site-isolation-trials'
+    ]
+  });
   const page = await browser.newPage();
   page.on('console', msg => console.log(msg.text()));
   page.on('pageerror', err => console.log(err)); // should not happen because we should have caught all errors with window.onerror

--- a/src/travix/js/run.js
+++ b/src/travix/js/run.js
@@ -8,9 +8,9 @@ var url = 'http://localhost:8912/run.html';
     headless: true,
     devtools: true,
     args: [
-        '--disable-web-security',
-        '--disable-features=IsolateOrigins',
-        '--disable-site-isolation-trials'
+      '--disable-web-security',
+      '--disable-features=IsolateOrigins',
+      '--disable-site-isolation-trials'
     ]
   });
   const page = await browser.newPage();


### PR DESCRIPTION
I had been having erratic behaviour (not working most of the time) with unit tests using auth cookies.
So, whether for merge or for others to see, here is a PR.

Note:
I suppose `bin/js/run.js` in user project is simply generated (copied) from `travix/src/js/run.js`, but for some reason
had to directly edit my generated `bin/js/run.js` with those changes. Perhaps the macro only writes it the first time; shameful but didn't check.

This solution uses the suggestion from https://stackoverflow.com/questions/52129649/puppeteer-cors-mistake/66744065#66744065

