### PR TITLE
Add Haxe 4.3 to the matrix and install pcre2 for Lua 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
           - macos-latest
           - windows-latest
         haxe:
+          - 4.3.3
           - 4.2.5
           - 4.1.5
           - 4.0.5

--- a/src/travix/commands/LuaCommand.hx
+++ b/src/travix/commands/LuaCommand.hx
@@ -71,7 +71,7 @@ class LuaCommand extends Command {
     }
 
     // Install lua libraries
-    exec('sudo', 'luarocks install haxe-deps'.split(' '));
+    exec('sudo', 'luarocks install pcre2 haxe-deps'.split(' '));
     exec('eval', ['sudo luarocks install environ 0.1.0-1']); // for haxe 3
 
     // print the effective versions


### PR DESCRIPTION
Lua target requires pcre2 since Haxe 4.3